### PR TITLE
more regular runs

### DIFF
--- a/.github/workflows/scheduled_runs.yml
+++ b/.github/workflows/scheduled_runs.yml
@@ -3,7 +3,7 @@ name: Trigger CalChecker
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
-    - cron: 0 22 * * *  # Every day at 22:00 UTC
+    - cron: 0 0/6 * * *  # Every six hours, every day
 
 jobs:
   build:


### PR DESCRIPTION
run every 6 hours

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request modifies the CI workflow schedule to trigger every six hours, increasing the frequency of runs from once daily.

* **CI**:
    - Updated the scheduled workflow to run every six hours instead of once daily.

<!-- Generated by sourcery-ai[bot]: end summary -->